### PR TITLE
Include by tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ The code doesn't know or care about the tag text. That's for humans. All it care
     -   Tag to exclude.
     -   Can be used multiple times.
     -   Example: `--exclude format:e-book -e genre:sci-fi`
+-   `--include`, `-i`
+    -   Tag to include.
+    -   Can be used multiple times.
+    -   Example: `--include format:e-book -i genre:sci-fi`

--- a/src/chooser.test.ts
+++ b/src/chooser.test.ts
@@ -84,6 +84,35 @@ describe('choose method', () => {
         });
     });
 
+    describe('inclusion by single tag', () => {
+        const alphaTag = new Tag('alpha');
+        const betaTag = new Tag('beta');
+        const gammaTag = new Tag('gamma');
+        const deltaTag = new Tag('delta');
+
+        const bookOne = new Book('Book One', someAuthor, someYear, someLink, 5, emptyDate, [alphaTag, gammaTag]);
+        const bookTwo = new Book('Book Two', someAuthor, someYear, someLink, 5, emptyDate, [betaTag, gammaTag]);
+
+        const testCases = [
+            ['tag exists on first book', 'alpha', bookOne],
+            ['tag exists on second book', 'beta', bookTwo],
+            ['tag exists on all books', 'gamma', bookOne],
+            ['tag is on no books', 'delta', null],
+        ];
+
+        it.each(testCases)('%s', (name: string, tagName: string, expectedBook: Book) => {
+            const books = [bookOne, bookTwo];
+            const choice = new Chooser({ includeTags: [tagName] }).choose(books);
+
+            if (expectedBook == null) {
+                expect(choice).toBeNull();
+            } else {
+                expect(choice).not.toBeNull();
+                expect(choice).toEqual(expectedBook);
+            }
+        });
+    });
+
     describe('ignore books currently being read', () => {
         const books = [
             new Book('Currently reading', someAuthor, someYear, someLink, 5, '28/10/2023', [positiveTag]),

--- a/src/chooser.ts
+++ b/src/chooser.ts
@@ -29,6 +29,13 @@ export class Chooser {
             });
         });
 
+        // Filter for any included tags
+        this.includeTags.forEach((tagName: string) => {
+            books = books.filter((book: Book) => {
+                return book.hasTag(tagName);
+            });
+        });
+
         // Sort in descending order
         books.sort((a, b) => {
             return b.getCalculatedRating() - a.getCalculatedRating();

--- a/src/chooser.ts
+++ b/src/chooser.ts
@@ -1,15 +1,18 @@
 import { Book } from './types';
 
 type Options = {
-    excludeTags: string[];
+    excludeTags?: string[];
+    includeTags?: string[];
 };
 
 export class Chooser {
     private excludeTags: string[] = [];
+    private includeTags: string[] = [];
 
     constructor(options?: Options) {
         if (options !== undefined) {
             this.excludeTags = options.excludeTags ?? [];
+            this.includeTags = options.includeTags ?? [];
         }
     }
 

--- a/src/cli-config.ts
+++ b/src/cli-config.ts
@@ -1,11 +1,13 @@
 import { ArgumentConfig, ParseOptions, UsageGuideConfig } from 'ts-command-line-args';
 
 export interface CliOptions {
+    include?: string[];
     exclude?: string[];
     help?: boolean;
 }
 
 const argumentConfig: ArgumentConfig<CliOptions> = {
+    include: { type: String, optional: true, multiple: true, alias: 'i', description: 'Tag to include' },
     exclude: { type: String, optional: true, multiple: true, alias: 'e', description: 'Tag to exclude' },
     help: { type: Boolean, optional: true, alias: 'h', description: 'Prints this usage guide' },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ async function main() {
 
     const chooser = new Chooser({
         excludeTags: args.exclude,
+        includeTags: args.include,
     });
 
     const choice = chooser.choose(books);


### PR DESCRIPTION
Add the ability to include by tag name. Addresses the remainder of https://github.com/biggianteye/book-chooser/issues/4.